### PR TITLE
Update install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ Install
 
 Run these commands in a terminal:
 
-    mkdir ~/bin
-    wget -O ~/bin/brew-cask-outdated https://raw.github.com/bgandon/brew-cask-outdated/blob/master/brew-cask-outdated.sh
-    chmod +x ~/bin/brew-cask-outdated
-    echo 'export PATH=$HOME/bin:$PATH' >> ~/.bashrc
+    curl https://raw.githubusercontent.com/bgandon/brew-cask-outdated/master/brew-cask-outdated.sh > /usr/local/bin/brew-cask-outdated
+    chmod +x /usr/local/bin/brew-cask-outdated
 
 If you know what it's about, please check that it's correct for your setup. If
 you don't, it doesn't matter. It shall work anyway.


### PR DESCRIPTION
Brew (and brew cask) install into the `/usr/local/bin/` directory. Let's install in there as well.

Not all systems have `wget` installed, but they do have `curl`.